### PR TITLE
Fix reserved identifier violations

### DIFF
--- a/chash.h
+++ b/chash.h
@@ -1,6 +1,6 @@
 /* chash.h */
-#ifndef _CHASH_H_
-#define _CHASH_H_
+#ifndef CHASH_H_F61CA1F6A58446FC9B38E829D2DF2187
+#define CHASH_H_F61CA1F6A58446FC9B38E829D2DF2187
 
 struct chash_t;
 


### PR DESCRIPTION
An identifier [does not fit](https://www.securecoding.cert.org/confluence/display/c/DCL37-C.+Do+not+declare+or+define+a+reserved+identifier#DCL37-C.Donotdeclareordefineareservedidentifier-NoncompliantCodeExample%28HeaderGuard%29 "Do not use identifiers that are reserved for the compiler implementation.") to the expected naming convention for the programming languages "C" and "C++". It can be renamed.

The probability for name clashes can also be reduced especially for include guards by the addition of an universally unique identifier.