### PR TITLE
Support out-of-source builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ ifeq ("$(INCDIR)", "")
 INCDIR=$(PREFIX)/include
 endif
 
+ifneq ($(strip $(srcdir)),)
+   VPATH::=$(srcdir)
+endif
+
 default: library
 
 .c.o:


### PR DESCRIPTION
Some implementations of the tool "make" can support the search for prerequisites also in directories which are specified by [the variable "VPATH"](https://www.gnu.org/software/make/manual/html_node/General-Search.html).
This variable can be set to the value of the variable "srcdir" if it was not empty.
